### PR TITLE
[ new ] implement different types of queries on graphs

### DIFF
--- a/indexed-graph.ipkg
+++ b/indexed-graph.ipkg
@@ -9,6 +9,7 @@ license    = "BSD-3 Clause"
 sourcedir  = "src"
 depends    = base    >= 0.5.1
            , array
+           , containers
 
 modules = Data.AssocList.Indexed
 

--- a/indexed-graph.ipkg
+++ b/indexed-graph.ipkg
@@ -15,3 +15,5 @@ modules = Data.AssocList.Indexed
         , Data.Graph.Indexed
         , Data.Graph.Indexed.Types
         , Data.Graph.Indexed.Util
+
+        , Data.Graph.Indexed.Query.Visited

--- a/indexed-graph.ipkg
+++ b/indexed-graph.ipkg
@@ -20,3 +20,4 @@ modules = Data.AssocList.Indexed
         , Data.Graph.Indexed.Query.BFS
         , Data.Graph.Indexed.Query.DFS
         , Data.Graph.Indexed.Query.Visited
+        , Data.Graph.Indexed.Query.Util

--- a/indexed-graph.ipkg
+++ b/indexed-graph.ipkg
@@ -17,4 +17,5 @@ modules = Data.AssocList.Indexed
         , Data.Graph.Indexed.Types
         , Data.Graph.Indexed.Util
 
+        , Data.Graph.Indexed.Query.DFS
         , Data.Graph.Indexed.Query.Visited

--- a/indexed-graph.ipkg
+++ b/indexed-graph.ipkg
@@ -17,5 +17,6 @@ modules = Data.AssocList.Indexed
         , Data.Graph.Indexed.Types
         , Data.Graph.Indexed.Util
 
+        , Data.Graph.Indexed.Query.BFS
         , Data.Graph.Indexed.Query.DFS
         , Data.Graph.Indexed.Query.Visited

--- a/pack.toml
+++ b/pack.toml
@@ -30,4 +30,3 @@ type   = "git"
 url    = "https://github.com/stefan-hoeck/idris2-containers"
 commit = "latest:main"
 ipkg   = "containers.ipkg"
-

--- a/pack.toml
+++ b/pack.toml
@@ -25,3 +25,9 @@ url    = "https://github.com/stefan-hoeck/idris2-array"
 commit = "latest:main"
 ipkg   = "array.ipkg"
 
+[custom.all.containers]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-containers"
+commit = "latest:main"
+ipkg   = "containers.ipkg"
+

--- a/profile/src/Main.idr
+++ b/profile/src/Main.idr
@@ -85,22 +85,23 @@ graphN = graph . pairs
 --          Visited
 --------------------------------------------------------------------------------
 
-testVisInteger : Integer -> List (Fin k) -> Bool
-testVisInteger i []        = testBit i 1
-testVisInteger i (x :: xs) =
-  case testBit i (finToNat x) of
-    False => testVisInteger (setBit i (finToNat x)) xs
-    True  => testVisInteger i xs
-
-testVisVisited : {k : _} -> List (Fin k) -> Bool
-testVisVisited xs = visiting k (go xs)
+testMVisited : {k : _} -> List (Fin k) -> Bool
+testMVisited xs = visiting k (go xs)
   where
-    go : List (Fin k) -> Visited k -@ Ur Bool
+    go : List (Fin k) -> MVisited k -@ Ur Bool
     go []        v = done True v
     go (x :: xs) v =
-      let False # v2 := visited x v | True # v2 => go xs v2
-          v3         := visit x v2
+      let False # v2 := mvisited x v | True # v2 => go xs v2
+          v3         := mvisit x v2
        in go xs v3
+
+testVisited : {k : _} -> List (Fin k) -> Bool
+testVisited xs = go xs ini
+  where
+    go : List (Fin k) -> Visited k -> Bool
+    go []        v = True
+    go (x :: xs) v =
+      if visited x v then go xs v else go xs (visit x v)
 
 --------------------------------------------------------------------------------
 --          Benchmarks
@@ -108,21 +109,21 @@ testVisVisited xs = visiting k (go xs)
 
 bench : Benchmark Void
 bench = Group "graph_ops"
-  [ Group "visited integer-based"
-      [ Single "1"     (basic (testVisInteger 0) $ allFinsFast 1)
-      , Single "32"    (basic (testVisInteger 0) $ allFinsFast 32)
-      , Single "64"    (basic (testVisInteger 0) $ allFinsFast 64)
-      , Single "128"   (basic (testVisInteger 0) $ allFinsFast 128)
-      , Single "1024"  (basic (testVisInteger 0) $ allFinsFast 1024)
-      , Single "65536" (basic (testVisInteger 0) $ allFinsFast 65536)
+  [ Group "Visited"
+      [ Single "1"     (basic testVisited $ allFinsFast 1)
+      , Single "32"    (basic testVisited $ allFinsFast 32)
+      , Single "64"    (basic testVisited $ allFinsFast 64)
+      , Single "128"   (basic testVisited $ allFinsFast 128)
+      , Single "1024"  (basic testVisited $ allFinsFast 1024)
+      , Single "65536" (basic testVisited $ allFinsFast 65536)
       ]
-  , Group "visited array-based"
-      [ Single "1"     (basic testVisVisited $ allFinsFast 1)
-      , Single "32"    (basic testVisVisited $ allFinsFast 32)
-      , Single "64"    (basic testVisVisited $ allFinsFast 64)
-      , Single "128"   (basic testVisVisited $ allFinsFast 128)
-      , Single "1024"  (basic testVisVisited $ allFinsFast 1024)
-      , Single "65536" (basic testVisVisited $ allFinsFast 65536)
+  , Group "MVisited"
+      [ Single "1"     (basic testMVisited $ allFinsFast 1)
+      , Single "32"    (basic testMVisited $ allFinsFast 32)
+      , Single "64"    (basic testMVisited $ allFinsFast 64)
+      , Single "128"   (basic testMVisited $ allFinsFast 128)
+      , Single "1024"  (basic testMVisited $ allFinsFast 1024)
+      , Single "65536" (basic testMVisited $ allFinsFast 65536)
       ]
   , Group "mkGraph map-based"
       [ Single "1"     (basic graph $ pairs 1)

--- a/profile/src/Main.idr
+++ b/profile/src/Main.idr
@@ -1,7 +1,9 @@
 module Main
 
+import Data.Bits
 import Data.Graph as G
 import Data.Graph.Indexed as I
+import Data.Graph.Indexed.Query.Visited
 import Profile
 
 %default total
@@ -47,7 +49,7 @@ graphData n =
    in GD ns es
 
 arrGraph : GraphData -> ArrGr () Nat
-arrGraph (GD ns es) = G _ $ mkGraph ns es
+arrGraph (GD ns es) = G _ $ mkGraphL ns es
 
 arrGraphN : Nat -> ArrGr () Nat
 arrGraphN = arrGraph . graphData
@@ -56,6 +58,9 @@ labM : Nat -> ArrGr () Nat -> Maybe Nat
 labM n (G k g) = case tryNatToFin {k} n of
   Just x => Just $ lab g x
   Nothing => Nothing
+
+insM : Nat -> ArrGr () Nat -> ArrGr () Nat
+insM n (G k g) = G _ $ insNodes g [n]
 
 --------------------------------------------------------------------------------
 --          Regular Graph Generation
@@ -77,51 +82,91 @@ graphN : Nat -> Gr () Nat
 graphN = graph . pairs
 
 --------------------------------------------------------------------------------
+--          Visited
+--------------------------------------------------------------------------------
+
+testVisInteger : Integer -> List (Fin k) -> Bool
+testVisInteger i []        = testBit i 1
+testVisInteger i (x :: xs) =
+  case testBit i (finToNat x) of
+    False => testVisInteger (setBit i (finToNat x)) xs
+    True  => testVisInteger i xs
+
+testVisVisited : {k : _} -> List (Fin k) -> Bool
+testVisVisited xs = visiting k (go xs)
+  where
+    go : List (Fin k) -> Visited k -@ Ur Bool
+    go []        v = done True v
+    go (x :: xs) v =
+      let False # v2 := visited x v | True # v2 => go xs v2
+          v3         := visit x v2
+       in go xs v3
+
+--------------------------------------------------------------------------------
 --          Benchmarks
 --------------------------------------------------------------------------------
 
 bench : Benchmark Void
-bench = Group "graph_ops" [
-    Group "mkGraph" [
-        Single "G 1"     (basic graph $ pairs 1)
-      , Single "A 1"     (basic arrGraph $ graphData 1)
-      , Single "G 10"    (basic graph $ pairs 10)
-      , Single "A 10"    (basic arrGraph $ graphData 10)
-      , Single "G 100"   (basic graph $ pairs 100)
-      , Single "A 100"   (basic arrGraph $ graphData 100)
-      , Single "G 1000"  (basic graph $ pairs 1000)
-      , Single "A 1000"  (basic arrGraph $ graphData 1000)
-      , Single "G 10000" (basic graph $ pairs 10000)
-      , Single "A 10000" (basic arrGraph $ graphData 10000)
+bench = Group "graph_ops"
+  [ Group "visited integer-based"
+      [ Single "1"     (basic (testVisInteger 0) $ allFinsFast 1)
+      , Single "32"    (basic (testVisInteger 0) $ allFinsFast 32)
+      , Single "64"    (basic (testVisInteger 0) $ allFinsFast 64)
+      , Single "128"   (basic (testVisInteger 0) $ allFinsFast 128)
+      , Single "1024"  (basic (testVisInteger 0) $ allFinsFast 1024)
+      , Single "65536" (basic (testVisInteger 0) $ allFinsFast 65536)
       ]
-  , Group "lab" [
-        Single "G 1"     (basic (`lab` 0) $ graphN 1)
-      , Single "A 1"     (basic (labM 0) $ arrGraphN 1)
-      , Single "G 10"    (basic (`lab` 5) $ graphN 10)
-      , Single "A 10"    (basic (labM 5) $ arrGraphN 10)
-      , Single "G 100"   (basic (`lab` 50) $ graphN 100)
-      , Single "A 100"   (basic (labM 50) $ arrGraphN 100)
-      , Single "G 1000"  (basic (`lab` 500) $ graphN 1000)
-      , Single "A 1000"  (basic (labM 500) $ arrGraphN 1000)
-      , Single "G 10000" (basic (`lab` 5000) $ graphN 10000)
-      , Single "A 10000" (basic (labM 5000) $ arrGraphN 10000)
+  , Group "visited array-based"
+      [ Single "1"     (basic testVisVisited $ allFinsFast 1)
+      , Single "32"    (basic testVisVisited $ allFinsFast 32)
+      , Single "64"    (basic testVisVisited $ allFinsFast 64)
+      , Single "128"   (basic testVisVisited $ allFinsFast 128)
+      , Single "1024"  (basic testVisVisited $ allFinsFast 1024)
+      , Single "65536" (basic testVisVisited $ allFinsFast 65536)
+      ]
+  , Group "mkGraph map-based"
+      [ Single "1"     (basic graph $ pairs 1)
+      , Single "10"    (basic graph $ pairs 10)
+      , Single "100"   (basic graph $ pairs 100)
+      , Single "1000"  (basic graph $ pairs 1000)
+      , Single "10000" (basic graph $ pairs 10000)
+      ]
+  , Group "mkGraph array-based"
+      [ Single "1"     (basic arrGraph $ graphData 1)
+      , Single "10"    (basic arrGraph $ graphData 10)
+      , Single "100"   (basic arrGraph $ graphData 100)
+      , Single "1000"  (basic arrGraph $ graphData 1000)
+      , Single "10000" (basic arrGraph $ graphData 10000)
+      ]
+  , Group "lab map-based"
+      [ Single "1"     (basic (`lab` 0)    $ graphN 1)
+      , Single "10"    (basic (`lab` 5)    $ graphN 10)
+      , Single "100"   (basic (`lab` 50)   $ graphN 100)
+      , Single "1000"  (basic (`lab` 500)  $ graphN 1000)
+      , Single "10000" (basic (`lab` 5000) $ graphN 10000)
+      ]
+  , Group "lab array-based"
+      [ Single "1"     (basic (labM 0)    $ arrGraphN 1)
+      , Single "10"    (basic (labM 5)    $ arrGraphN 10)
+      , Single "100"   (basic (labM 50)   $ arrGraphN 100)
+      , Single "1000"  (basic (labM 500)  $ arrGraphN 1000)
+      , Single "10000" (basic (labM 5000) $ arrGraphN 10000)
+      ]
+  , Group "insert map-based"
+      [ Single "1"     (basic (insNode 1 1)     $ graphN 1)
+      , Single "10"    (basic (insNode 11 1)    $ graphN 10)
+      , Single "100"   (basic (insNode 111 1)   $ graphN 100)
+      , Single "1000"  (basic (insNode 1111 1)  $ graphN 1000)
+      , Single "10000" (basic (insNode 11111 1) $ graphN 10000)
+      ]
+  , Group "insert array-based"
+      [ Single "1"     (basic (insM 1) $ arrGraphN 1)
+      , Single "10"    (basic (insM 1) $ arrGraphN 10)
+      , Single "100"   (basic (insM 1) $ arrGraphN 100)
+      , Single "1000"  (basic (insM 1) $ arrGraphN 1000)
+      , Single "10000" (basic (insM 1) $ arrGraphN 10000)
       ]
   ]
---   , Group "insert" [
---         Single "1"     (basic (insert 333 "") $ full 1)
---       , Single "10"    (basic (insert 333 "") $ full 10)
---       , Single "100"   (basic (insert 333 "") $ full 100)
---       , Single "1000"  (basic (insert 333 "") $ full 1000)
---       , Single "10000" (basic (insert 333 "") $ full 10000)
---       ]
---   , Group "delete" [
---         Single "1"     (basic (delete 333) $ full 1)
---       , Single "10"    (basic (delete 333) $ full 10)
---       , Single "100"   (basic (delete 333) $ full 100)
---       , Single "1000"  (basic (delete 333) $ full 1000)
---       , Single "10000" (basic (delete 333) $ full 10000)
---       ]
---   ]
 
 main : IO ()
 main = runDefault (const True) Table show bench

--- a/src/Data/Graph/Indexed/Query/BFS.idr
+++ b/src/Data/Graph/Indexed/Query/BFS.idr
@@ -2,34 +2,10 @@ module Data.Graph.Indexed.Query.BFS
 
 import Data.Queue
 import Data.Graph.Indexed
+import Data.Graph.Indexed.Query.Util
 import Data.Graph.Indexed.Query.Visited
 
 %default total
-
---------------------------------------------------------------------------------
--- Utilities
---------------------------------------------------------------------------------
-
-%inline fromLeft : Either a Void -> a
-fromLeft (Left v) = v
-fromLeft (Right _) impossible
-
-%inline fleft : (a -> b -> c -> a) -> a -> b -> c -> Either a Void
-fleft f x y = Left . f x y
-
--- Internal alias for stateful functions when visiting small graphs
-0 Vis : Nat -> Type -> Type
-Vis k s = Visited k -> (s, Visited k)
-
--- Internal alias for stateful functions when visiting large graphs
-0 MVis : Nat -> Type -> Type
-MVis k s = MVisited k -@ CRes s (MVisited k)
-
-%inline fromLeftMVis : CRes (Either a Void) (MVisited k) -@ CRes a (MVisited k)
-fromLeftMVis (x # m) = fromLeft x # m
-
-%inline fromLeftVis : (Either a Void, Visited k) -> (a, Visited k)
-fromLeftVis (v,x) = (fromLeft v, x)
 
 parameters {k : Nat}
            (g : IGraph k e n)
@@ -74,11 +50,11 @@ parameters {k : Nat}
         in bfsS q3 f st2 (assert_smaller v $ visit x v)
 
   %inline bfsL' : Queue (Nat,Fin k) -> (s -> Nat -> Fin k -> s) -> s -> MVis k s
-  bfsL' xs acc i v = fromLeftMVis $ bfsL xs (fleft acc) i v
+  bfsL' xs acc i v = fromLeftMVis $ bfsL xs (fleft3 acc) i v
 
   -- flat BFS implementation for small graphs
   %inline bfsS' : Queue (Nat,Fin k) -> (s -> Nat -> Fin k -> s) -> s -> Vis k s
-  bfsS' xs acc i v = fromLeftVis $ bfsS xs (fleft acc) i v
+  bfsS' xs acc i v = fromLeftVis $ bfsS xs (fleft3 acc) i v
 
   ||| Traverses the graph in breadth-first order for the given
   ||| start nodes and accumulates the nodes encountered with the
@@ -98,7 +74,7 @@ parameters {k : Nat}
   ||| accumulating the nodes encountered with the given function.
   export %inline
   bfsWith' : (acc : s -> Nat -> Fin k -> s) -> (init : s) -> Fin k -> s
-  bfsWith' acc init = fromLeft . bfsWith (fleft acc) init
+  bfsWith' acc init = fromLeft . bfsWith (fleft3 acc) init
 
   ||| Traverses the whole graph in breadth-first order
   ||| returning the encountered nodes in a `SnocList`.

--- a/src/Data/Graph/Indexed/Query/BFS.idr
+++ b/src/Data/Graph/Indexed/Query/BFS.idr
@@ -1,0 +1,129 @@
+module Data.Graph.Indexed.Query.BFS
+
+import Data.Queue
+import Data.Graph.Indexed
+import Data.Graph.Indexed.Query.Visited
+
+%default total
+
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- Internal alias for stateful functions when visiting small graphs
+0 Vis : Nat -> Type -> Type
+Vis k s = Visited k -> (s, Visited k)
+
+-- Internal alias for stateful functions when visiting large graphs
+0 MVis : Nat -> Type -> Type
+MVis k s = MVisited k -@ CRes s (MVisited k)
+
+parameters {k : Nat}
+           (g : IGraph k e n)
+
+  -- TODO: this should be dropped and `neighbours` and `lneighbours` adjusted
+  %inline nbours : Fin k -> List (Fin k)
+  nbours x = keys $ neighbours g x
+
+--------------------------------------------------------------------------------
+-- Flat BFS traversals
+--------------------------------------------------------------------------------
+
+  -- flat BFS implementation for large graphs
+  bfsL : Queue (Fin k) -> (s -> Fin k -> s) -> s -> MVis k s
+  bfsL q f st v =
+    case dequeue q of
+      Nothing     => st # v
+      Just (x,q2) =>
+       let False # v2 := mvisited x v
+             | True # v2 => bfsL q2 f st (assert_smaller v v2)
+           q3         := enqueueAll q2 (nbours x)
+        in bfsL q3 f (f st x) (assert_smaller v $ mvisit x v2)
+
+  -- flat BFS implementation for small graphs
+  bfsS : Queue (Fin k) -> (s -> Fin k -> s) -> s -> Vis k s
+  bfsS q f st v =
+    case dequeue q of
+      Nothing     => (st,v)
+      Just (x,q2) =>
+       let False := visited x v | True => bfsS q2 f st (assert_smaller v v)
+           q3    := enqueueAll q2 (nbours x)
+        in bfsS q3 f (f st x) (assert_smaller v $ visit x v)
+
+  ||| Traverses the graph in depth-first order for the given
+  ||| start nodes and accumulates the nodes encountered with the
+  ||| given function.
+  export
+  bfsWith : (acc : s -> Fin k -> s) -> (init : s) -> List (Fin k) -> s
+  bfsWith acc init xs =
+    if k < 64
+       then fst $ bfsS (fromList xs) acc init ini
+       else visiting' k (bfsL (fromList xs) acc init)
+
+  ||| Traverses the whole graph in depth-first order
+  ||| accumulates the nodes encountered with the given function.
+  export %inline
+  bfsWith' : (acc : s -> Fin k -> s) -> (init : s) -> s
+  bfsWith' acc init = bfsWith acc init (allFinsFast k)
+
+  ||| Traverses the graph in depth-first order for the given start nodes
+  ||| returning the encountered nodes in a `SnocList`.
+  export %inline
+  bfs : List (Fin k) -> SnocList (Fin k)
+  bfs = bfsWith (:<) [<]
+
+  ||| Traverses the whole graph in depth-first order
+  ||| returning the encountered nodes in a `SnocList`.
+  export %inline
+  bfs' : SnocList (Fin k)
+  bfs' = bfsWith' (:<) [<]
+
+--------------------------------------------------------------------------------
+-- Flat component-wise BFS traversals
+--------------------------------------------------------------------------------
+
+  -- flat component-wise DFS implementation for large graphs
+  cbfsL : (s -> Fin k -> s) -> s -> SnocList s -> List (Fin k) -> MVis k (List s)
+  cbfsL f i ss []      v = (ss <>> []) # v
+  cbfsL f i ss (x::xs) v =
+    let False # v2 := mvisited x v | True # v2 => cbfsL f i ss xs v2
+        y # v3     := bfsL (fromList [x]) f i v2
+     in cbfsL f i (ss:<y) xs v3
+
+  -- flat component-wise DFS implementation for small graphs
+  cbfsS : (s -> Fin k -> s) -> s -> SnocList s -> List (Fin k) -> Vis k (List s)
+  cbfsS f i ss []      v = (ss <>> [], v)
+  cbfsS f i ss (x::xs) v =
+    if visited x v then cbfsS f i ss xs v
+    else let (y,v2) := bfsS (fromList [x]) f i v in cbfsS f i (ss:<y) xs v2
+
+  ||| Traverses the graph in depth-first order for the given
+  ||| start nodes and accumulates the nodes encountered with the
+  ||| given function.
+  |||
+  ||| Unlike with `bfsWith`, results are accumulated component-wise,
+  ||| using initial state `init` for every component we encounter.
+  export
+  cbfsWith : (acc : s -> Fin k -> s) -> (init : s) -> List (Fin k) -> List s
+  cbfsWith acc init xs =
+    if k < 64
+       then fst $ cbfsS acc init [<] xs ini
+       else visiting' k (cbfsL acc init [<] xs)
+
+  ||| Traverses the whole graph in depth-first order
+  ||| accumulates the nodes encountered with the given function.
+  export %inline
+  cbfsWith' : (acc : s -> Fin k -> s) -> (init : s) -> List s
+  cbfsWith' acc init = cbfsWith acc init (allFinsFast k)
+
+  ||| Traverses the graph in depth-first order for the given start nodes
+  ||| returning the encountered nodes in a `SnocList`.
+  export %inline
+  cbfs : List (Fin k) -> List (SnocList (Fin k))
+  cbfs = cbfsWith (:<) [<]
+
+  ||| Traverses the whole graph in depth-first order
+  ||| returning the encountered nodes in a `SnocList`.
+  export %inline
+  cbfs' : List (SnocList (Fin k))
+  cbfs' = cbfsWith' (:<) [<]

--- a/src/Data/Graph/Indexed/Query/DFS.idr
+++ b/src/Data/Graph/Indexed/Query/DFS.idr
@@ -1,3 +1,6 @@
+||| This modules provides several functions for traversing
+||| graphs in depth-first order and accumulating results in
+||| various ways along the way.
 module Data.Graph.Indexed.Query.DFS
 
 import Data.Tree
@@ -6,6 +9,18 @@ import Data.Graph.Indexed.Query.Visited
 
 %default total
 
+--------------------------------------------------------------------------------
+-- Utilities
+--------------------------------------------------------------------------------
+
+-- Internal alias for stateful functions when visiting small graphs
+0 Vis : Nat -> Type -> Type
+Vis k s = Visited k -> (s, Visited k)
+
+-- Internal alias for stateful functions when visiting large graphs
+0 MVis : Nat -> Type -> Type
+MVis k s = MVisited k -@ CRes s (MVisited k)
+
 parameters {k : Nat}
            (g : IGraph k e n)
 
@@ -13,17 +28,21 @@ parameters {k : Nat}
   %inline nbours : Fin k -> List (Fin k)
   nbours x = keys $ neighbours g x
 
+--------------------------------------------------------------------------------
+-- Flat DFS traversals
+--------------------------------------------------------------------------------
+
   -- flat DFS implementation for large graphs
-  dfsL : List (Fin k) -> (s -> Fin k -> s) -> s -> MVisited k -@ Ur s
-  dfsL []      f st v = done st v
+  dfsL : List (Fin k) -> (s -> Fin k -> s) -> s -> MVis k s
+  dfsL []      f st v = st # v
   dfsL (x::xs) f st v =
     let False # v2 := mvisited x v
           | True # v2 => dfsL xs f st (assert_smaller v v2)
      in dfsL (nbours x ++ xs) f (f st x) (assert_smaller v $ mvisit x v2)
 
   -- flat DFS implementation for small graphs
-  dfsS : List (Fin k) -> (s -> Fin k -> s) -> s -> Visited k -> s
-  dfsS []      f st v = st
+  dfsS : List (Fin k) -> (s -> Fin k -> s) -> s -> Vis k s
+  dfsS []      f st v = (st, v)
   dfsS (x::xs) f st v =
     if visited x v then dfsS xs f st v
     else dfsS (nbours x ++ xs) f (f st x) (assert_smaller v $ visit x v)
@@ -34,7 +53,9 @@ parameters {k : Nat}
   export
   dfsWith : (acc : s -> Fin k -> s) -> (init : s) -> List (Fin k) -> s
   dfsWith acc init xs =
-    if k < 64 then dfsS xs acc init ini else visiting k (dfsL xs acc init)
+    if k < 64
+       then fst $ dfsS xs acc init ini
+       else visiting' k (dfsL xs acc init)
 
   ||| Traverses the whole graph in depth-first order
   ||| accumulates the nodes encountered with the given function.
@@ -54,12 +75,62 @@ parameters {k : Nat}
   dfs' : SnocList (Fin k)
   dfs' = dfsWith' (:<) [<]
 
+--------------------------------------------------------------------------------
+-- Component-wise DFS traversals
+--------------------------------------------------------------------------------
+
+  -- flat component-wise DFS implementation for large graphs
+  cdfsL : (s -> Fin k -> s) -> s -> SnocList s -> List (Fin k) -> MVis k (List s)
+  cdfsL f i ss []      v = (ss <>> []) # v
+  cdfsL f i ss (x::xs) v =
+    let False # v2 := mvisited x v | True # v2 => cdfsL f i ss xs v2
+        y # v3     := dfsL [x] f i v2
+     in cdfsL f i (ss:<y) xs v3
+
+  -- flat component-wise DFS implementation for small graphs
+  cdfsS : (s -> Fin k -> s) -> s -> SnocList s -> List (Fin k) -> Vis k (List s)
+  cdfsS f i ss []      v = (ss <>> [], v)
+  cdfsS f i ss (x::xs) v =
+    if visited x v then cdfsS f i ss xs v
+    else let (y,v2) := dfsS [x] f i v in cdfsS f i (ss:<y) xs v2
+
+  ||| Traverses the graph in depth-first order for the given
+  ||| start nodes and accumulates the nodes encountered with the
+  ||| given function.
+  |||
+  ||| Unlike with `dfsWith`, results are accumulated component-wise,
+  ||| using initial state `init` for every component we encounter.
+  export
+  cdfsWith : (acc : s -> Fin k -> s) -> (init : s) -> List (Fin k) -> List s
+  cdfsWith acc init xs =
+    if k < 64
+       then fst $ cdfsS acc init [<] xs ini
+       else visiting' k (cdfsL acc init [<] xs)
+
+  ||| Traverses the whole graph in depth-first order
+  ||| accumulates the nodes encountered with the given function.
+  export %inline
+  cdfsWith' : (acc : s -> Fin k -> s) -> (init : s) -> List s
+  cdfsWith' acc init = cdfsWith acc init (allFinsFast k)
+
+  ||| Traverses the graph in depth-first order for the given start nodes
+  ||| returning the encountered nodes in a `SnocList`.
+  export %inline
+  cdfs : List (Fin k) -> List (SnocList (Fin k))
+  cdfs = cdfsWith (:<) [<]
+
+  ||| Traverses the whole graph in depth-first order
+  ||| returning the encountered nodes in a `SnocList`.
+  export %inline
+  cdfs' : List (SnocList (Fin k))
+  cdfs' = cdfsWith' (:<) [<]
+
+--------------------------------------------------------------------------------
+-- Tree-shaped DFS traversals
+--------------------------------------------------------------------------------
+
   -- tree-based DFS implementation for large graphs
-  dffL :
-       (Fin k -> t)
-    -> List (Fin k)
-    -> MVisited k
-    -@ CRes (Forest t) (MVisited k)
+  dffL : (Fin k -> t) -> List (Fin k) -> MVisited k -@ CRes (Forest t) (MVisited k)
   dffL f []      v = [] # v
   dffL f (x::xs) v =
       let False # v2 := mvisited x v
@@ -69,11 +140,7 @@ parameters {k : Nat}
        in (T (f x) ts :: fs) # v4
 
   -- tree-based DFS implementation for small graphs
-  dffS :
-       (Fin k -> t)
-    -> List (Fin k)
-    -> Visited k
-    -> (Forest t, Visited k)
+  dffS : (Fin k -> t) -> List (Fin k) -> Visited k -> (Forest t, Visited k)
   dffS f []      v = ([], v)
   dffS f (x::xs) v =
     if visited x v then dffS f xs v
@@ -122,14 +189,14 @@ parameters {k : Nat}
   dff' : Forest (Fin k)
   dff' = dffWith' id
 
-----------------------------------------------------------------------
+--------------------------------------------------------------------------------
 -- ALGORITHMS BASED ON DFS
-----------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
   ||| Collection of connected components
   export %inline
-  components : List (List $ Fin k)
-  components = map flatten dff'
+  components : List (SnocList $ Fin k)
+  components = cdfs'
 
   ||| Number of connected components
   export %inline

--- a/src/Data/Graph/Indexed/Query/DFS.idr
+++ b/src/Data/Graph/Indexed/Query/DFS.idr
@@ -6,34 +6,10 @@ module Data.Graph.Indexed.Query.DFS
 import Data.Either
 import Data.Tree
 import Data.Graph.Indexed
+import Data.Graph.Indexed.Query.Util
 import Data.Graph.Indexed.Query.Visited
 
 %default total
-
---------------------------------------------------------------------------------
--- Utilities
---------------------------------------------------------------------------------
-
-%inline fromLeft : Either a Void -> a
-fromLeft (Left v) = v
-fromLeft (Right _) impossible
-
-%inline fleft : (a -> b -> a) -> a -> b -> Either a Void
-fleft f x = Left . f x
-
--- Internal alias for stateful functions when visiting small graphs
-0 Vis : Nat -> Type -> Type
-Vis k s = Visited k -> (s, Visited k)
-
--- Internal alias for stateful functions when visiting large graphs
-0 MVis : Nat -> Type -> Type
-MVis k s = MVisited k -@ CRes s (MVisited k)
-
-%inline fromLeftMVis : CRes (Either a Void) (MVisited k) -@ CRes a (MVisited k)
-fromLeftMVis (x # m) = fromLeft x # m
-
-%inline fromLeftVis : (Either a Void, Visited k) -> (a, Visited k)
-fromLeftVis (v,x) = (fromLeft v, x)
 
 parameters {k : Nat}
            (g : IGraph k e n)
@@ -65,11 +41,11 @@ parameters {k : Nat}
        in dfsS (nbours x ++ xs) f st2 (assert_smaller v $ visit x v)
 
   %inline dfsL' : List (Fin k) -> (s -> Fin k -> s) -> s -> MVis k s
-  dfsL' xs acc i v = fromLeftMVis $ dfsL xs (fleft acc) i v
+  dfsL' xs acc i v = fromLeftMVis $ dfsL xs (fleft2 acc) i v
 
   -- flat DFS implementation for small graphs
   %inline dfsS' : List (Fin k) -> (s -> Fin k -> s) -> s -> Vis k s
-  dfsS' xs acc i v = fromLeftVis $ dfsS xs (fleft acc) i v
+  dfsS' xs acc i v = fromLeftVis $ dfsS xs (fleft2 acc) i v
 
   ||| Traverses the graph in depth-first order from the given
   ||| start node and accumulates the nodes encountered with the
@@ -89,7 +65,7 @@ parameters {k : Nat}
   ||| from the given starting node in depth-first order.
   export %inline
   dfsWith' : (acc : s -> Fin k -> s) -> (init : s) -> Fin k -> s
-  dfsWith' acc init = fromLeft . dfsWith (fleft acc) init
+  dfsWith' acc init = fromLeft . dfsWith (fleft2 acc) init
 
   ||| Traverses the graph in depth-first order for the given start nodes
   ||| returning the encountered nodes in a `SnocList`.

--- a/src/Data/Graph/Indexed/Query/DFS.idr
+++ b/src/Data/Graph/Indexed/Query/DFS.idr
@@ -1,0 +1,151 @@
+module Data.Graph.Indexed.Query.DFS
+
+import Data.Tree
+import Data.Graph.Indexed
+import Data.Graph.Indexed.Query.Visited
+
+%default total
+
+parameters {k : Nat}
+           (g : IGraph k e n)
+
+  -- TODO: this should be dropped and `neighbours` and `lneighbours` adjusted
+  %inline nbours : Fin k -> List (Fin k)
+  nbours x = keys $ neighbours g x
+
+  -- flat DFS implementation for large graphs
+  dfsL :
+       SnocList t
+    -> (Fin k -> t)
+    -> List (Fin k)
+    -> MVisited k
+    -@ Ur (List t)
+  dfsL sx f []      v = done (sx <>> []) v
+  dfsL sx f (x::xs) v =
+    let False # v2 := mvisited x v
+          | True # v2 => dfsL sx f xs (assert_smaller v v2)
+     in dfsL (sx :< f x) f (nbours x ++ xs) (assert_smaller v $ mvisit x v2)
+
+  -- flat DFS implementation for small graphs
+  dfsS :
+       SnocList t
+    -> (Fin k -> t)
+    -> List (Fin k)
+    -> Visited k
+    -> List t
+  dfsS sx f []      v = sx <>> []
+  dfsS sx f (x::xs) v =
+    if visited x v then dfsS sx f xs v
+    else dfsS (sx :< f x) f (nbours x ++ xs) (assert_smaller v $ visit x v)
+
+  ||| Traverses the graph in depth-first order for the given
+  ||| start nodes and converts the nodes encountered with the
+  ||| given function.
+  export
+  dfsWith : (Fin k -> t) -> List (Fin k) -> List t
+  dfsWith f xs =
+    if k < 64 then dfsS [<] f xs ini else visiting k (dfsL [<] f xs)
+
+  ||| Traverses the whole graph in depth-first order
+  ||| converts the nodes encountered with the given function.
+  export %inline
+  dfsWith' : (Fin k -> t) -> List t
+  dfsWith' f = dfsWith f (allFinsFast k)
+
+  ||| Traverses the graph in depth-first order for the given start nodes
+  ||| returning the encountered nodes in a list.
+  export %inline
+  dfs : List (Fin k) -> List (Fin k)
+  dfs = dfsWith id
+
+  ||| Traverses the whole graph in depth-first order
+  ||| returning the encountered nodes in a list.
+  export %inline
+  dfs' : List (Fin k)
+  dfs' = dfsWith' id
+
+  -- tree-based DFS implementation for large graphs
+  dffL :
+       (Fin k -> t)
+    -> List (Fin k)
+    -> MVisited k
+    -@ CRes (Forest t) (MVisited k)
+  dffL f []      v = [] # v
+  dffL f (x::xs) v =
+      let False # v2 := mvisited x v
+            | True # v2 => dffL f xs (assert_smaller v v2)
+          ts # v3 := dffL f (nbours x) (assert_smaller v $ mvisit x v2)
+          fs # v4 := dffL f xs (assert_smaller v v3)
+       in (T (f x) ts :: fs) # v4
+
+  -- tree-based DFS implementation for small graphs
+  dffS :
+       (Fin k -> t)
+    -> List (Fin k)
+    -> Visited k
+    -> (Forest t, Visited k)
+  dffS f []      v = ([], v)
+  dffS f (x::xs) v =
+    if visited x v then dffS f xs v
+    else
+      let (ts,v2) := dffS f (nbours x) (assert_smaller v $ visit x v)
+          (fs,v3) := dffS f xs (assert_smaller v v2)
+       in (T (f x) ts :: fs, v3)
+
+  ||| Traverses the graph in depth-first order for the given
+  ||| start nodes and converts the nodes encountered with the
+  ||| given function.
+  |||
+  ||| Unlike `dfsWith`, this returns a forest of spanning trees
+  ||| of the connected components encountered.
+  export
+  dffWith : (Fin k -> t) -> List (Fin k) -> Forest t
+  dffWith f xs =
+    if k < 64
+       then fst $ dffS f xs ini
+       else visiting k $ \v => let fs # v2 := dffL f xs v in done fs v2
+
+  ||| Traverses the whole graph in depth-first order
+  ||| converts the nodes encountered with the given function.
+  |||
+  ||| Unlike `dfsWith'`, this returns a forest of spanning trees
+  ||| of the connected components encountered.
+  export %inline
+  dffWith' : (Fin k -> t) -> Forest t
+  dffWith' f = dffWith f (allFinsFast k)
+
+  ||| Traverses the graph in depth-first order for the given start nodes
+  ||| returning the encountered nodes in a list.
+  |||
+  ||| Unlike `dfs`, this returns a forest of spanning trees
+  ||| of the connected components encountered.
+  export %inline
+  dff : List (Fin k) -> Forest (Fin k)
+  dff = dffWith id
+
+  ||| Traverses the whole graph in depth-first order
+  ||| returning the encountered nodes in a list.
+  |||
+  ||| Unlike `dfs'`, this returns a forest of spanning trees
+  ||| of the connected components encountered.
+  export %inline
+  dff' : Forest (Fin k)
+  dff' = dffWith' id
+
+----------------------------------------------------------------------
+-- ALGORITHMS BASED ON DFS
+----------------------------------------------------------------------
+
+  ||| Collection of connected components
+  export %inline
+  components : List (List $ Fin k)
+  components = map flatten dff'
+
+  ||| Number of connected components
+  export %inline
+  noComponents : Nat
+  noComponents = length components
+
+  ||| Is the graph connected?
+  isConnected : Bool
+  isConnected = noComponents == 1

--- a/src/Data/Graph/Indexed/Query/DFS.idr
+++ b/src/Data/Graph/Indexed/Query/DFS.idr
@@ -29,7 +29,7 @@ parameters {k : Nat}
     else dfsS (nbours x ++ xs) f (f st x) (assert_smaller v $ visit x v)
 
   ||| Traverses the graph in depth-first order for the given
-  ||| start nodes and converts the nodes encountered with the
+  ||| start nodes and accumulates the nodes encountered with the
   ||| given function.
   export
   dfsWith : (acc : s -> Fin k -> s) -> (init : s) -> List (Fin k) -> s
@@ -37,19 +37,19 @@ parameters {k : Nat}
     if k < 64 then dfsS xs acc init ini else visiting k (dfsL xs acc init)
 
   ||| Traverses the whole graph in depth-first order
-  ||| converts the nodes encountered with the given function.
+  ||| accumulates the nodes encountered with the given function.
   export %inline
   dfsWith' : (acc : s -> Fin k -> s) -> (init : s) -> s
   dfsWith' acc init = dfsWith acc init (allFinsFast k)
 
   ||| Traverses the graph in depth-first order for the given start nodes
-  ||| returning the encountered nodes in a list.
+  ||| returning the encountered nodes in a `SnocList`.
   export %inline
   dfs : List (Fin k) -> SnocList (Fin k)
   dfs = dfsWith (:<) [<]
 
   ||| Traverses the whole graph in depth-first order
-  ||| returning the encountered nodes in a list.
+  ||| returning the encountered nodes in a `SnocList`.
   export %inline
   dfs' : SnocList (Fin k)
   dfs' = dfsWith' (:<) [<]

--- a/src/Data/Graph/Indexed/Query/Util.idr
+++ b/src/Data/Graph/Indexed/Query/Util.idr
@@ -1,0 +1,42 @@
+||| Utilities for graph traversals.
+module Data.Graph.Indexed.Query.Util
+
+import Data.Graph.Indexed.Query.Visited
+
+%default total
+
+||| Extract a value from a `Left` because we know the `Right` is
+||| uninhabited.
+public export %inline
+fromLeft : Either a Void -> a
+fromLeft (Left v) = v
+fromLeft (Right _) impossible
+
+||| Convert a binary function to one returning an `Left`
+public export %inline
+fleft2 : (a -> b -> c) -> a -> b -> Either c Void
+fleft2 f x = Left . f x
+
+||| Convert a ternary function to one returning an `Left`
+public export %inline
+fleft3 : (a -> b -> c -> d) -> a -> b -> c -> Either d Void
+fleft3 f x y = Left . f x y
+
+||| Internal alias for stateful functions when visiting small graphs
+public export
+0 Vis : Nat -> Type -> Type
+Vis k s = Visited k -> (s, Visited k)
+
+||| Internal alias for stateful functions when visiting large graphs
+public export
+0 MVis : Nat -> Type -> Type
+MVis k s = MVisited k -@ CRes s (MVisited k)
+
+export %inline
+fromLeftMVis : CRes (Either a Void) (MVisited k) -@ CRes a (MVisited k)
+fromLeftMVis (x # m) = fromLeft x # m
+
+export %inline
+fromLeftVis : (Either a Void, Visited k) -> (a, Visited k)
+fromLeftVis (v,x) = (fromLeft v, x)
+

--- a/src/Data/Graph/Indexed/Query/Visited.idr
+++ b/src/Data/Graph/Indexed/Query/Visited.idr
@@ -42,8 +42,8 @@ mask = 7
 %inline bits : Nat
 bits = 3
 
-%inline shift : Integer -> Integer
-shift = (`shiftR` bits)
+%inline ix : Integer -> Integer
+ix = (`shiftR` bits)
 
 %inline bit : Integer -> Bits8
 bit n = cast n .&. mask
@@ -53,7 +53,7 @@ setBit v i = v .|. prim__shl_Bits8 1 (bit i)
 
 testBit : Bits8 -> Integer -> Bool
 testBit x b =
-  case x .&. prim__shl_Bits8 x (bit b) of
+  case x .&. prim__shl_Bits8 1 (bit b) of
     0 => False
     _ => True
 
@@ -70,13 +70,11 @@ record Visited (k : Nat) where
 
 visit' : Integer -> Visited k -@ Visited k
 visit' i (V b) =
-  let o   := shift i
+  let o   := ix i
    in V $ set' o (setBit (prim__getByte b o) i) b
 
 visited' : Integer -> Visited k -@ CRes Bool (Visited k)
-visited' i (V b) =
-  let bit := cast i .&. 7
-   in testBit (prim__getByte b $ shift i) i # V b
+visited' i (V b) = testBit (prim__getByte b $ ix i) i # V b
 
 ||| Set the current node to "visited".
 export %inline
@@ -98,4 +96,4 @@ done x (V _) = MkBang x
 export %inline
 visiting : (k : Nat) -> (Visited k -@ Ur a) -> a
 visiting k f =
-  unrestricted $ f (V $ prim__newBuf (1 + cast (Visited.shift $ cast k)))
+  unrestricted $ f (V $ prim__newBuf (1 + cast (Visited.ix $ cast k)))

--- a/src/Data/Graph/Indexed/Query/Visited.idr
+++ b/src/Data/Graph/Indexed/Query/Visited.idr
@@ -93,6 +93,19 @@ visiting k f =
   let i := cast {to = Integer} k `shiftR` bits
    in unrestricted $ f (MV $ prim__newBuf (1 + cast i))
 
+||| Allocate a linear byte array and use it to run the given
+||| computation, discarding it at the end.
+|||
+||| This is a convenience alias for `visiting` for those cases, where
+||| we already have a function returning a linear pair of values.
+export %inline
+visiting' : (k : Nat) -> (MVisited k -@ CRes a (MVisited k)) -> a
+visiting' k f =
+  let i        := cast {to = Integer} k `shiftR` bits
+      res # v  := f (MV $ prim__newBuf (1 + cast i))
+      MkBang v := done res v
+   in v
+
 --------------------------------------------------------------------------------
 --          Visited
 --------------------------------------------------------------------------------

--- a/src/Data/Graph/Indexed/Query/Visited.idr
+++ b/src/Data/Graph/Indexed/Query/Visited.idr
@@ -1,0 +1,101 @@
+module Data.Graph.Indexed.Query.Visited
+
+import Data.Bits
+import Data.Buffer
+import public Data.Array.Mutable
+
+%default total
+
+--------------------------------------------------------------------------------
+--          FFI
+--------------------------------------------------------------------------------
+
+%foreign "scheme:blodwen-buffer-getbyte"
+         "node:lambda:(buf,offset)=>buf.readUInt8(Number(offset))"
+prim__getByte : Buffer -> (offset : Integer) -> Bits8
+
+%foreign "scheme:blodwen-buffer-setbyte"
+         "node:lambda:(buf,offset,value)=>buf.writeUInt8(value, Number(offset))"
+prim__setByte : Buffer -> (offset : Integer) -> (val : Bits8) -> PrimIO ()
+
+%foreign "scheme:blodwen-new-buffer"
+         "node:lambda:s=>Buffer.alloc(s)"
+prim__newBuf : Bits32 -> Buffer
+
+destroy : (1 _ : %World) -> a -> a
+destroy %MkWorld x = x
+
+set' : (m : Integer) -> Bits8 -> Buffer -> Buffer
+set' m y b =
+  let MkIORes () w2 := prim__setByte b m y %MkWorld
+   in destroy w2 b
+
+--------------------------------------------------------------------------------
+--          Utilities
+--------------------------------------------------------------------------------
+
+-- the first three bits set to 1
+%inline mask : Bits8
+mask = 7
+
+-- number of bits in 8
+%inline bits : Nat
+bits = 3
+
+%inline shift : Integer -> Integer
+shift = (`shiftR` bits)
+
+%inline bit : Integer -> Bits8
+bit n = cast n .&. mask
+
+%inline setBit : Bits8 -> Integer -> Bits8
+setBit v i = v .|. prim__shl_Bits8 1 (bit i)
+
+testBit : Bits8 -> Integer -> Bool
+testBit x b =
+  case x .&. prim__shl_Bits8 x (bit b) of
+    0 => False
+    _ => True
+
+--------------------------------------------------------------------------------
+--          Visited
+--------------------------------------------------------------------------------
+
+||| Wraps a mutable byte array for keeping track of the visited nodes
+||| in a graph.
+export
+record Visited (k : Nat) where
+  constructor V
+  buf : Buffer
+
+visit' : Integer -> Visited k -@ Visited k
+visit' i (V b) =
+  let o   := shift i
+   in V $ set' o (setBit (prim__getByte b o) i) b
+
+visited' : Integer -> Visited k -@ CRes Bool (Visited k)
+visited' i (V b) =
+  let bit := cast i .&. 7
+   in testBit (prim__getByte b $ shift i) i # V b
+
+||| Set the current node to "visited".
+export %inline
+visit : Fin k -> Visited k -@ Visited k
+visit = visit' . cast
+
+||| Test, if the current node has been visited.
+export %inline
+visited : Fin k -> Visited k -@ CRes Bool (Visited k)
+visited = visited' . cast
+
+||| Discard the linear byte array and return the current result.
+export
+done : a -> Visited k -@ Ur a
+done x (V _) = MkBang x
+
+||| Allocate a linear byte array and use it to run the given
+||| computation.
+export %inline
+visiting : (k : Nat) -> (Visited k -@ Ur a) -> a
+visiting k f =
+  unrestricted $ f (V $ prim__newBuf (1 + cast (Visited.shift $ cast k)))

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -2,6 +2,7 @@ module Main
 
 import AssocList
 import Hedgehog
+import Visited
 
 %default total
 
@@ -9,4 +10,5 @@ main : IO ()
 main =
   test
     [ AssocList.props
+    , Visited.props
     ]

--- a/test/src/Visited.idr
+++ b/test/src/Visited.idr
@@ -5,8 +5,8 @@ import Test.Data.Graph.Indexed.Generators
 
 %default total
 
-prop_initUnset : Property
-prop_initUnset = property $ do
+prop_minitUnset : Property
+prop_minitUnset = property $ do
   k <- forAll (nat $ linear 0 127)
   n <- forAll (anyFin {k})
   assert (test n)
@@ -15,28 +15,40 @@ prop_initUnset = property $ do
     test : {k : _} -> Fin k -> Bool
     test n =
       visiting k $ \v =>
-        let b # v2 := visited n v in done (not b) v2
+        let b # v2 := mvisited n v in done (not b) v2
 
+prop_iniUnset : Property
+prop_iniUnset = property $ do
+  k <- forAll (nat $ linear 0 127)
+  n <- forAll (anyFin {k})
+  assert (not $ visited n ini)
+
+prop_mset : Property
+prop_mset = property $ do
+  k <- forAll (nat $ linear 0 127)
+  n <- forAll (anyFin {k})
+  assert (test n)
+
+  where
+    test : {k : _} -> Fin k -> Bool
+    test n =
+      visiting k $ \v =>
+        let v2     := mvisit n v
+            b # v3 := mvisited n v2
+         in done b v3
 
 prop_set : Property
 prop_set = property $ do
   k <- forAll (nat $ linear 0 127)
   n <- forAll (anyFin {k})
-  assert (test n)
-
-  where
-    test : {k : _} -> Fin k -> Bool
-    test n =
-      visiting k $ \v =>
-        let v2     := visit n v
-            b # v3 := visited n v2
-         in done b v3
-
+  assert (visited n $ visit n ini)
 
 export
 props : Group
 props =
   MkGroup "Visited"
-    [ ("prop_initUnset", prop_initUnset)
+    [ ("prop_minitUnset", prop_minitUnset)
+    , ("prop_mset", prop_mset)
+    , ("prop_iniUnset", prop_iniUnset)
     , ("prop_set", prop_set)
     ]

--- a/test/src/Visited.idr
+++ b/test/src/Visited.idr
@@ -1,0 +1,42 @@
+module Visited
+
+import Data.Graph.Indexed.Query.Visited
+import Test.Data.Graph.Indexed.Generators
+
+%default total
+
+prop_initUnset : Property
+prop_initUnset = property $ do
+  k <- forAll (nat $ linear 0 127)
+  n <- forAll (anyFin {k})
+  assert (test n)
+
+  where
+    test : {k : _} -> Fin k -> Bool
+    test n =
+      visiting k $ \v =>
+        let b # v2 := visited n v in done (not b) v2
+
+
+prop_set : Property
+prop_set = property $ do
+  k <- forAll (nat $ linear 0 127)
+  n <- forAll (anyFin {k})
+  assert (test n)
+
+  where
+    test : {k : _} -> Fin k -> Bool
+    test n =
+      visiting k $ \v =>
+        let v2     := visit n v
+            b # v3 := visited n v2
+         in done b v3
+
+
+export
+props : Group
+props =
+  MkGroup "Visited"
+    [ ("prop_initUnset", prop_initUnset)
+    , ("prop_set", prop_set)
+    ]


### PR DESCRIPTION
The goal of this PR is to add several kinds of queries such as depth-first search and breath-first search to this library. This will also require the addition of one or more types for keeping track of the nodes we visited so far during a query.

TODOs:
- [x] Implement a linear `Visited` type based on mutable byte arrays to be used with large graphs
- [x]  Thoroughly test `Visited` to work correctly
- [x]  Profile `Visited` to determine the number of nodes for which `Visited` starts to beat `Integer`
- [x]  Implement several generalized DFS algorithms (taken from Haskell's FGL library)
- [x]  Same as above but for BFS