### PR TITLE
[ new ] add functions for creating edges from lesser Fins

### DIFF
--- a/src/Data/Graph/Indexed/Types.idr
+++ b/src/Data/Graph/Indexed/Types.idr
@@ -142,14 +142,14 @@ incEdge k (E n1 n2 l @{prf}) =
     l
 
 ||| Creates an edge between two nodes from different graphs,
-||| resulting in a new edge of their compound graph.
+||| resulting in a new edge of their composite graph.
 |||
 ||| Note: This assumes that nodes in the first graph (of order `k`)
 |||       will stay the same, while nodes in the second graph
 |||       (of order `m`) will be increased by `k`.
 export
-compoundEdge : {k : _} -> Fin k -> Fin m -> (l : e) -> Edge (k+m) e
-compoundEdge x y l =
+compositeEdge : {k : _} -> Fin k -> Fin m -> (l : e) -> Edge (k+m) e
+compositeEdge x y l =
   fromNat
     (finToNat x)
     (k + finToNat y)


### PR DESCRIPTION
In this PR, two new functions for creating edges are added:

* `incEdge` increases the nodes of an existing edge by the same natural number. This will allow us to to create the composite of two graphs, as a new disconnected graph. While the nodes of one graph will keep their numeric value, the nodes of the second graph will have to be increased by the order of the first graph. The same goes for the edges of the second graph, where function `incEdge` will come into play.
* `compositeEdge` comes with the same use case in mind: Composing two graphs. This function, however, will allow us to add edges from one graph to the other as long as we have a node from each graph. Again, the node of the first graph will keep its numeric value but will require weakening, while the node of the second graph will be increased by the order of the first graph.

For both use cases we can proof that the result will be a valid edge without having to go via a `Maybe`.