### PR TITLE
[ fix ] function edgesTo

### DIFF
--- a/src/Data/Graph/Indexed/Util.idr
+++ b/src/Data/Graph/Indexed/Util.idr
@@ -117,7 +117,9 @@ neighbours g = keys . neighbours . adj g
 ||| Returns the list of edges connecting a node.
 export %inline
 edgesTo : IGraph k e n -> Fin k -> List (Edge k e)
-edgesTo g k = ctxtEdges k (adj g k) <>> []
+edgesTo g k =
+  let A _ ns := adj g k
+   in mapMaybe (\(n,l) => mkEdge k n l) $ pairs ns
 
 ||| Returns the list of neighboring nodes paired with their
 ||| corresponding labels.

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -4,6 +4,7 @@ import AssocList
 import BFS
 import Hedgehog
 import Subgraphs
+import Util
 import Visited
 
 %default total
@@ -12,6 +13,7 @@ main : IO ()
 main =
   test
     [ AssocList.props
+    , Util.props
     , Visited.props
     , Subgraphs.props
     , BFS.props

--- a/test/src/Util.idr
+++ b/test/src/Util.idr
@@ -1,0 +1,38 @@
+module Util
+
+import Data.AssocList.Indexed
+import Test.Data.Graph.Indexed.Generators
+
+%default total
+
+--------------------------------------------------------------------------------
+-- Generators
+--------------------------------------------------------------------------------
+
+smallGraphs : Gen (Graph Bits8 Bits8)
+smallGraphs = sparseGraph (linear 0 30) (linear 0 100) anyBits8 anyBits8
+
+--------------------------------------------------------------------------------
+-- Tests
+--------------------------------------------------------------------------------
+
+testEdgesTo : Eq e => IGraph k e n -> Fin k -> Bool
+testEdgesTo g n =
+  let vs := values $ neighbours (adj g n)
+   in vs == map label (edgesTo g n)
+
+--------------------------------------------------------------------------------
+-- Properties
+--------------------------------------------------------------------------------
+
+prop_edgesTo : Property
+prop_edgesTo = property $ do
+  G o g <- forAll smallGraphs
+  assert $ all (testEdgesTo g) (nodes g)
+
+export
+props : Group
+props =
+  MkGroup "Util"
+    [ ("prop_edgesTo", prop_edgesTo)
+    ]


### PR DESCRIPTION
Currently, function `edgesTo` returns only edges to nodes larger than the scrutinee. This is a bug that's fixed by this PR.