### PR TITLE
[ new ] limited breadth first searches

### DIFF
--- a/src/Data/Graph/Indexed/Query/Visited.idr
+++ b/src/Data/Graph/Indexed/Query/Visited.idr
@@ -75,6 +75,12 @@ mvisit i (MV b) =
   let o   := ix i
    in MV $ set' o (setBit (prim__getByte b o) i) b
 
+||| Set all given nodes to "visited"
+export
+mvisitAll : List (Fin k) -> MVisited k -@ MVisited k
+mvisitAll []      m = m
+mvisitAll (v::vs) m = mvisitAll vs (mvisit v m)
+
 ||| Test, if the current node has been visited.
 export
 mvisited : Fin k -> MVisited k -@ CRes Bool (MVisited k)
@@ -129,6 +135,11 @@ ini = V 0
 export
 visit : Fin k -> Visited k -> Visited k
 visit i (V b) = V $ setBit b (finToNat i)
+
+||| Set all given nodes to "visited".
+export %inline
+visitAll : List (Fin k) -> Visited k -> Visited k
+visitAll vs v = foldl (flip visit) v vs
 
 ||| Test, if the current node has been visited.
 export


### PR DESCRIPTION
This PR adds an enhancement to our breadth first search routines: We can now declare certain nodes in the graph to be "taboo", that is, they will be set to "visited" at the beginning of the breadth first traversal. This allows us to easily find the smallest cycle an edge belongs to or to find a specific cycle along a sequence of edges.

