### PR TITLE
[ new ] extract the ring bonds from a graph

### DIFF
--- a/indexed-graph.ipkg
+++ b/indexed-graph.ipkg
@@ -23,3 +23,5 @@ modules = Data.AssocList.Indexed
         , Data.Graph.Indexed.Query.Subgraph
         , Data.Graph.Indexed.Query.Visited
         , Data.Graph.Indexed.Query.Util
+
+        , Data.Graph.Indexed.Ring.Bonds

--- a/src/Data/Graph/Indexed/Ring/Bonds.idr
+++ b/src/Data/Graph/Indexed/Ring/Bonds.idr
@@ -1,0 +1,28 @@
+module Data.Graph.Indexed.Ring.Bonds
+
+import Data.SortedSet
+import Data.Graph.Indexed
+import Data.Graph.Indexed.Subgraph
+
+%default total
+
+||| A set of unlabeled edges of order `k`
+public export
+0 EdgeSet : (k : Nat) -> Type
+EdgeSet k = SortedSet (Edge k ())
+
+parameters {k : Nat}
+           (g : IGraph k e n)
+
+  ||| Adds the edges of a subgraph to an edge set
+  export
+  addEdges : EdgeSet k -> Subgraph k e n -> EdgeSet k
+  addEdges x (G o h) =
+    foldl (\s => maybe s (\x => insert (ignore x) s) . originEdge h) x $ edges h
+
+  ||| Computes the cyclic bonds in a graph.
+  |||
+  ||| This justs collects the edges from the biconnected components.
+  export
+  ringBonds : EdgeSet k
+  ringBonds = foldl addEdges empty (biconnectedComponents g)

--- a/src/Data/Graph/Indexed/Subgraph.idr
+++ b/src/Data/Graph/Indexed/Subgraph.idr
@@ -75,6 +75,22 @@ export
 connectedComponents : {k : _} -> IGraph k e n -> List (Subgraph k e n)
 connectedComponents g = subgraphL g . (<>> []) <$> components g
 
+||| Converts the node of a subgraph to the corresponding node in the
+||| original graph.
+export
+origin : ISubgraph k m e n -> Fin k -> Fin m
+origin s = fst . lab s
+
+||| Converts the edge of a subgraph to the corresponding edge in the
+||| original graph.
+|||
+||| This comes with the potential of failure, since we cannot prove that
+||| the subgraph is injective, that is, distinct nodes in the subgraph
+||| point at distinct nodes in the original graph.
+export
+originEdge : ISubgraph k m e n -> Edge k e -> Maybe (Edge m e)
+originEdge s (E x y l) = mkEdge (origin s x) (origin s y) l
+
 --------------------------------------------------------------------------------
 -- Biconnected Components
 --------------------------------------------------------------------------------

--- a/src/Data/Graph/Indexed/Types.idr
+++ b/src/Data/Graph/Indexed/Types.idr
@@ -179,11 +179,33 @@ public export
 Eq e => Eq (Edge k e) where
   E m1 n1 l1 == E m2 n2 l2 = m1 == m2 && n1 == n2 && l1 == l2
 
+public export
+Ord e => Ord (Edge k e) where
+  compare (E m1 n1 l1) (E m2 n2 l2) =
+    let EQ := compare m1 m2 | r => r
+        EQ := compare n1 n2 | r => r
+     in compare l1 l2
+
 export
 Show e => Show (Edge k e) where
   showPrec p (E x y l) =
     showCon p "E" $ showArg (finToNat x) ++ showArg (finToNat y) ++ showArg l
 
+export
+Functor (Edge k) where
+  map f (E x y l) = E x y (f l)
+
+export
+Foldable (Edge k) where
+  foldl f x (E _ _ l) = f x l
+  foldr f x (E _ _ l) = f l x
+  toList (E _ _ l)    = [l]
+  foldMap f (E _ _ l) = f l
+  null _              = False
+
+export
+Traversable (Edge k) where
+  traverse f (E x y l) = map (\v => E x y v) (f l)
 --------------------------------------------------------------------------------
 --          Context
 --------------------------------------------------------------------------------

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -4,6 +4,7 @@ import AssocList
 import BFS
 import DFS
 import Hedgehog
+import Ring.Bonds
 import SubgraphIso
 import Subgraphs
 import Util
@@ -15,10 +16,11 @@ main : IO ()
 main =
   test
     [ AssocList.props
-    , Util.props
-    , Visited.props
-    , Subgraphs.props
     , BFS.props
     , DFS.props
+    , Ring.Bonds.props
     , SubgraphIso.props
+    , Subgraphs.props
+    , Util.props
+    , Visited.props
     ]

--- a/test/src/Ring/Bonds.idr
+++ b/test/src/Ring/Bonds.idr
@@ -1,0 +1,47 @@
+module Ring.Bonds
+
+import Data.Graph.Indexed.Ring.Bonds
+import Data.SortedSet
+import Test.Data.Graph.Indexed.Generators
+import Text.Smiles.Simple
+
+%default total
+
+toEdge : {o : _} -> (Nat, Nat) -> Maybe (Edge o ())
+toEdge (x,y) = do
+  fx <- tryNatToFin x
+  fy <- tryNatToFin y
+  mkEdge fx fy ()
+
+rbTest : String -> List (Nat,Nat) -> Property
+rbTest s ps =
+  property1 $ assert $ case readSmiles s of
+    Nothing => False
+    Just (G o g) =>
+      let rbs := ringBonds g
+       in all (maybe False (`contains` rbs) . toEdge) ps
+
+prop_ethanol : Property
+prop_ethanol = rbTest "CCO" []
+
+prop_benzene : Property
+prop_benzene =
+  rbTest "C1=CC=CC=C1" [(0,1),(1,2),(2,3),(3,4),(4,5),(0,5)]
+
+prop_bicycle : Property
+prop_bicycle =
+  rbTest "C12CC1CC2" [(0,1),(0,2),(0,4),(1,2),(2,3),(3,4)]
+
+prop_disconnected : Property
+prop_disconnected =
+  rbTest "C1CC1.C1CCC1" [(0,1),(0,2),(1,2),(3,4),(4,5),(5,6),(3,6)]
+
+export
+props : Group
+props =
+  MkGroup "Ring.Bonds"
+    [ ("prop_ethanol", prop_ethanol)
+    , ("prop_benzene", prop_benzene)
+    , ("prop_bicycle", prop_bicycle)
+    , ("prop_disconnected", prop_disconnected)
+    ]


### PR DESCRIPTION
This adds functionality for extracting the ring bonds of a graph from its biconnected components. @beesRawes0me : This is only marginally related to your thesis. You might want to have a quick look, if you can make use of it and otherwise just ignore it.