### PR TITLE
[ new ] function to test three-membered ring membership

### DIFF
--- a/indexed-graph.ipkg
+++ b/indexed-graph.ipkg
@@ -25,3 +25,4 @@ modules = Data.AssocList.Indexed
         , Data.Graph.Indexed.Query.Util
 
         , Data.Graph.Indexed.Ring.Bonds
+        , Data.Graph.Indexed.Ring.Util

--- a/src/Data/Graph/Indexed/Ring/Bonds.idr
+++ b/src/Data/Graph/Indexed/Ring/Bonds.idr
@@ -2,14 +2,10 @@ module Data.Graph.Indexed.Ring.Bonds
 
 import Data.SortedSet
 import Data.Graph.Indexed
+import Data.Graph.Indexed.Ring.Util
 import Data.Graph.Indexed.Subgraph
 
 %default total
-
-||| A set of unlabeled edges of order `k`
-public export
-0 EdgeSet : (k : Nat) -> Type
-EdgeSet k = SortedSet (Edge k ())
 
 parameters {k : Nat}
            (g : IGraph k e n)
@@ -18,7 +14,7 @@ parameters {k : Nat}
   export
   addEdges : EdgeSet k -> Subgraph k e n -> EdgeSet k
   addEdges x (G o h) =
-    foldl (\s => maybe s (\x => insert (ignore x) s) . originEdge h) x $ edges h
+    foldl (\s,(E a b _) => addEdge s (origin h a) (origin h b)) x $ edges h
 
   ||| Computes the cyclic bonds in a graph.
   |||

--- a/src/Data/Graph/Indexed/Ring/Util.idr
+++ b/src/Data/Graph/Indexed/Ring/Util.idr
@@ -1,9 +1,40 @@
 module Data.Graph.Indexed.Ring.Util
 
+import Data.SortedSet
 import Data.Graph.Indexed
 import Data.SnocList
 
 %default total
+
+||| A set of unlabeled edges of order `k`
+public export
+0 EdgeSet : (k : Nat) -> Type
+EdgeSet k = SortedSet (Edge k ())
+
+||| Adds an unlabeled edge to an edge set.
+|||
+||| The edge set is returned unmodified, if the two nodes are
+||| identical.
+export
+addEdge : EdgeSet k -> Fin k -> Fin k -> EdgeSet k
+addEdge es x y = maybe es (`insert` es) (mkEdge x y ())
+
+||| Adds an unlabeled edge to an edge set.
+|||
+||| The edge set is returned unmodified, if the two natural numbers
+||| are not valid distinct nodes of order `k`.
+export
+addNatEdge : {k : _} -> EdgeSet k -> Nat -> Nat -> EdgeSet k
+addNatEdge es x y =
+  let Just fx := tryNatToFin x | Nothing => es
+      Just fy := tryNatToFin y | Nothing => es
+   in addEdge es fx fy
+
+||| Converts a list of pairs of natural number to an edge set of
+||| order `k`. Invalid pairs of nodes are silently dropped.
+export
+toEdgeSet : {k : _} -> List (Nat,Nat) -> EdgeSet k
+toEdgeSet = foldl (\es,(x,y) => addNatEdge es x y) empty
 
 nodePairs : SnocList (a,a) -> List a -> SnocList (a,a)
 nodePairs sp []     = sp

--- a/src/Data/Graph/Indexed/Ring/Util.idr
+++ b/src/Data/Graph/Indexed/Ring/Util.idr
@@ -1,0 +1,20 @@
+module Data.Graph.Indexed.Ring.Util
+
+import Data.Graph.Indexed
+import Data.SnocList
+
+%default total
+
+nodePairs : SnocList (a,a) -> List a -> SnocList (a,a)
+nodePairs sp []     = sp
+nodePairs sp (h::t) = nodePairs (sp <>< map (h,) t) t
+
+||| True, if the given node is a member of a three-membered cycle.
+|||
+||| For sparse graphs, this check can be performed in linear time without
+||| performing a proper ring detection, just be checking if two of the
+||| neighbours of the given node are adjacent.
+export
+inThreeMemberedRing : IGraph k e n -> Fin k -> Bool
+inThreeMemberedRing g x =
+  any (\(a,b) => adjacent g a b) (nodePairs [<] (neighbours g x))

--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -5,9 +5,10 @@ import BFS
 import DFS
 import Hedgehog
 import Ring.Bonds
+import Ring.Util as RU
 import SubgraphIso
 import Subgraphs
-import Util
+import Util as U
 import Visited
 
 %default total
@@ -19,8 +20,9 @@ main =
     , BFS.props
     , DFS.props
     , Ring.Bonds.props
+    , RU.props
     , SubgraphIso.props
     , Subgraphs.props
-    , Util.props
+    , U.props
     , Visited.props
     ]

--- a/test/src/Ring/Bonds.idr
+++ b/test/src/Ring/Bonds.idr
@@ -1,6 +1,7 @@
 module Ring.Bonds
 
 import Data.Graph.Indexed.Ring.Bonds
+import Data.Graph.Indexed.Ring.Util
 import Data.SortedSet
 import Test.Data.Graph.Indexed.Generators
 import Text.Smiles.Simple
@@ -17,9 +18,7 @@ rbTest : String -> List (Nat,Nat) -> Property
 rbTest s ps =
   property1 $ assert $ case readSmiles s of
     Nothing => False
-    Just (G o g) =>
-      let rbs := ringBonds g
-       in all (maybe False (`contains` rbs) . toEdge) ps
+    Just (G o g) => ringBonds g == toEdgeSet ps
 
 prop_ethanol : Property
 prop_ethanol = rbTest "CCO" []

--- a/test/src/Ring/Util.idr
+++ b/test/src/Ring/Util.idr
@@ -1,0 +1,26 @@
+module Ring.Util
+
+import Data.Graph.Indexed.Ring.Util
+import Data.List
+import Data.SortedSet
+import Test.Data.Graph.Indexed.Generators
+import Text.Smiles.Simple
+
+%default total
+
+ring3Test : String -> List Nat -> Property
+ring3Test s ns =
+  property1 $ assert $ case readSmiles s of
+    Nothing      => False
+    Just (G o g) =>
+      sort (map cast $ filter (inThreeMemberedRing g) (nodes g)) == ns
+
+export
+props : Group
+props =
+  MkGroup "Ring.Util"
+    [ ("prop_ethanol", ring3Test "CCO" [])
+    , ("prop_benzene", ring3Test "C1=CC=CC=C1" [])
+    , ("prop_bicycle", ring3Test "C12CC1CC2" [0,1,2])
+    , ("prop_disconnected", ring3Test "CC.C1OC1.C1CCC1" [2,3,4])
+    ]


### PR DESCRIPTION
A simple test for three-memberd cycle membership: A node is part of a three-membered ring, if and only if two of its neighbours are adjacent. When working with sparse graphs, this check can be performed in constant time without any other form of cycle detection.

Three-membered cycles play a special role in chemistry and are often treated specially when computing molecular descriptors.