### PR TITLE
[ cleanup ] remove some unneeded duplicate code

### DIFF
--- a/profile/src/Main.idr
+++ b/profile/src/Main.idr
@@ -90,10 +90,10 @@ testMVisited : {k : _} -> List (Fin k) -> Bool
 testMVisited xs = visiting k (go xs)
   where
     go : List (Fin k) -> MVis k Bool
-    go []        t = True # t
-    go (x :: xs) t =
-      let False # t2 := mvisited x t | True # t2 => go xs t2
-       in go xs (mvisit x t2)
+    go []        r t = True # t
+    go (x :: xs) r t =
+      let False # t := mvisited r x t | True # t => go xs r t
+       in go xs r (mvisit r x t)
 
 testVisited : {k : _} -> List (Fin k) -> Bool
 testVisited xs = go xs ini

--- a/src/Data/Graph/Indexed/Query/Util.idr
+++ b/src/Data/Graph/Indexed/Query/Util.idr
@@ -22,11 +22,6 @@ public export %inline
 fleft3 : (a -> b -> c -> d) -> a -> b -> c -> Either d Void
 fleft3 f x y = Left . f x y
 
-||| Internal alias for stateful functions when visiting small graphs
-public export
-0 Vis : Nat -> Type -> Type
-Vis k s = Visited k -> (s, Visited k)
-
 ||| Internal alias for stateful functions when visiting large graphs
 public export
 0 MVis : Nat -> Type -> Type
@@ -35,7 +30,3 @@ MVis = WithMBuffer
 export %inline
 fromLeftMVis : R1 s (Either a Void) -@ R1 s a
 fromLeftMVis (x # m) = fromLeft x # m
-
-export %inline
-fromLeftVis : (Either a Void, Visited k) -> (a, Visited k)
-fromLeftVis (v,x) = (fromLeft v, x)


### PR DESCRIPTION
Profiling showed that the pure `Visited` is redundant: The bitwise ops are slowing things down compared to just using an uncompressed byte array. I'll keep it in the library for the time being, but I removed all query implementations using `Visited` for small graphs with less than 64 nodes.